### PR TITLE
15 update sql style guide with sqlfluff rulesnotes

### DIFF
--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -12,10 +12,10 @@ This guide establishes our standards for SQL and are enforced by code review. So
 * Avoid large select statements with multiple tables instead utilize CTEs.
 * If a `select` statement is so large it can't be easily comprehended, it would be better to refactor it into multiple smaller CTEs that are later joined back together.
 
-* Lines should ideally not be longer than 120 characters.
+* Lines should ideally not be longer than 120 characters.**
 Very long lines are harder to read, especially in situations where space may be limited like on smaller screens or in side-by-side version control diffs.
 
-* Identifiers such as aliases and CTE names should be in lowercase `snake_case`.
+* Identifiers such as aliases and CTE names should be in lowercase `snake_case`.**
 It's more readable, easier to keep consistent, and avoids having to quote identifiers due to capitalization, spaces, or other special characters.
 
 * Never use reserved words as identifiers.
@@ -23,6 +23,11 @@ Otherwise the identifier will have to be quoted everywhere it's used. [(Snowflak
 
 * Never use tab characters.
 It's easier to keep things consistent in version control when only space characters are used. By default, VS Code inserts spaces and uses 4 space per `Tab` key. [(source)](https://code.visualstudio.com/docs/editor/codebasics#_indentation)
+
+| **SQL Style Guide Rule** | **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|:---|
+| **Lines should ideally not be longer than 120 characters | max_line_length | Yes |
+| **Identifiers such as aliases and CTE names should be in lowercase. | [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01), [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes |
 
 
 ## Syntax
@@ -52,11 +57,16 @@ select COUNT(*) as customers_count
 from customers
 ```
 
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01), [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes |
+
 ### Operators 
 
  Use `!=` instead of `<>`.
  
  `!=` reads like "not equal" which is closer to how we'd say it out loud.
+
 
 ### Aliases 
 Always use the `as` keyword when aliasing columns, expressions, and tables.
@@ -70,6 +80,10 @@ from customers
 select count(*) customers_count
 from customers
 ```
+
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [AL01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL01), [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02), [AL03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL03)| Yes |
 
 ### Grouping 
 

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -373,7 +373,7 @@ from paying_customers_per_month
 ```
 | **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
 |:---|:---|
-| [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br /> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes |
+| [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes |
 
 
 ### Subqueries 

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -97,9 +97,6 @@ from customers
 select max(id)
 from customers
 ```
-| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
-|:---|:---|
-| [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02) | Yes |
 
 
 ### Where vs Having

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -193,7 +193,9 @@ from customers
 where email like '''%@domain.com'''
 -- Will probably be interpreted like '\'%domain.com\''.
 ```
-
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [CV10](https://docs.sqlfluff.com/en/stable/rules.html#rule-CV10) | Yes |
 
 ## Joins
 
@@ -203,6 +205,10 @@ Don't use `using` in joins.
   - Having all joins use `on` is more consistent.
   - If additional join conditions need to be added later, `on` is easier to adapt.
   - `using` can produce inconsistent results with outer joins in some databases.
+
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [ST07](https://docs.sqlfluff.com/en/stable/rules.html#rule-ST07) | Yes |
 
 
 Be explicit with all join types for example use `inner join` instead of just `join`.
@@ -302,6 +308,7 @@ where orders.total_amount >= 100
   - CTE names should not be prefixed or suffixed with `cte`.
   - CTEs with confusing or notable logic should be commented.
 
+
 ### Formatting:
   - Start each CTE on its own line, indented one level more than `with` (including the first one, and even if there is only one).
   - Use a single blank line around CTEs to add visual separation.
@@ -364,7 +371,9 @@ with paying_customers as (
 select ...
 from paying_customers_per_month
 ```
-
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes |
 
 
 ### Subqueries 
@@ -478,6 +487,10 @@ where email like '%@domain.com'
   and plan_name != 'free'
 ```
 
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT02](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT02) | Yes |
+
 ### Do's and Don't 
 
 **Don't** end a line with an operator like `and`, `or`, `+`, `||`, etc.
@@ -500,6 +513,11 @@ where
     email like '%@domain.com' and
     plan_name != 'free'
 ```
+
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT03](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT03) | Yes |
+
 
 **Do** use trailing commas
 
@@ -582,6 +600,10 @@ select distinct
 -- Bad
 select distinct state, country
 ```
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT09](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT09), [LT10](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT109)  | Yes |
+
 
 
 **Do** follow these standards when using the `from` clause:
@@ -707,6 +729,9 @@ where plan_name in ( 'monthly', 'yearly' )
 
 
 ```
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT01](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT01) | Yes |
 
 
 ### Case statements:

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -375,7 +375,7 @@ from paying_customers_per_month
 ```
 | **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
 |:---|:---|
-| [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes |
+| [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br /> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes |
 
 
 ### Subqueries 

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -275,6 +275,11 @@ from customers
 inner join orders on customers.id = orders.customer_id
 ```
 
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [RF02](https://docs.sqlfluff.com/en/stable/rules.html#rule-RF02) | No |
+
+
 ### Filter using where
 
 When  joining, put filter conditions in the `where` clause instead of the `join` clause.

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -59,7 +59,7 @@ from customers
 
 | **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
 |:---|:---|
-| [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01), [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes |
+| [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01), [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03), [CP04](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP04) | Yes |
 
 ### Operators 
 
@@ -97,6 +97,10 @@ from customers
 select max(id)
 from customers
 ```
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02) | Yes |
+
 
 ### Where vs Having
 Use `where` instead of `having` when either would suffice.
@@ -107,6 +111,7 @@ Queries filter on the `where` clause earlier in their processing, so `where` fil
 
 Use `union all` instead of `union` unless duplicate rows really do need to be removed.
 `union all` is more performant because it doesn't have to sort and de-duplicate the rows.
+
 
 ### Order by
 
@@ -214,6 +219,10 @@ select *
 from customers
 join orders on customers.id = orders.customer_id
 ```
+
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes |
 
 In join conditions, put the table that was referenced first immediately after `on`.
 This makes it easier to determine if the join is going to cause the results to fan out.
@@ -420,6 +429,11 @@ from customers as c
 inner join orders as o on c.id = o.customer_id
 ```
 
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes |
+
+
 
 ## Formatting
 The general guide for formatting is:
@@ -528,6 +542,10 @@ where email in (
         , 'user-3@example.com'
     )
 ```
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [LT04](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT04) | Yes |
+
 
 
 **Do** follow these standards when using the `select` clause:
@@ -668,6 +686,11 @@ order by plan_name, signup_month
 order by plan_name
     , signup_month
 ```
+
+| **SQLFluff Rule Code** | **SQLFluff Fix compatible** |
+|:---|:---|
+| [AM06](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM06) | Yes |
+
 
 **Don't** put extra spaces inside of parentheses.
 

--- a/cdp-docs/docs/project_resources/sql_style_guide.md
+++ b/cdp-docs/docs/project_resources/sql_style_guide.md
@@ -12,11 +12,9 @@ This guide establishes our standards for SQL and are enforced by code review. So
 * Avoid large select statements with multiple tables instead utilize CTEs.
 * If a `select` statement is so large it can't be easily comprehended, it would be better to refactor it into multiple smaller CTEs that are later joined back together.
 
-* Lines should ideally not be longer than 120 characters.**
-Very long lines are harder to read, especially in situations where space may be limited like on smaller screens or in side-by-side version control diffs.
+* Lines should ideally not be longer than 120 characters. Very long lines are harder to read, especially in situations where space may be limited like on smaller screens or in side-by-side version control diffs.**
 
-* Identifiers such as aliases and CTE names should be in lowercase `snake_case`.**
-It's more readable, easier to keep consistent, and avoids having to quote identifiers due to capitalization, spaces, or other special characters.
+* Identifiers such as aliases and CTE names should be in lowercase `snake_case`. It's more readable, easier to keep consistent, and avoids having to quote identifiers due to capitalization, spaces, or other special characters.**
 
 * Never use reserved words as identifiers.
 Otherwise the identifier will have to be quoted everywhere it's used. [(Snowflake's reserved words)](https://docs.snowflake.com/en/sql-reference/reserved-keywords)

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -31,7 +31,7 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 | Use single quotes for strings. | [CV10](https://docs.sqlfluff.com/en/stable/rules.html#rule-CV10) | Yes | No |
 | Don't use `using` in joins. | [ST07](https://docs.sqlfluff.com/en/stable/rules.html#rule-STO7) | Yes | No |
 | Start each CTE on its own line, Use a single blank line around CTEs to add visual separation | [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes | No |
-| Don't end a line with an operator like `and`, `or`, `+`, `||`, etc | [LT03](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT03) | Yes | Yes |
+| Don't end a line with an operator like `and`, `or`, `+`, <code>&vert;&vert;</code> etc | [LT03](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT03) | Yes | Yes |
 | If there is only one column expression, put it on the same line as select. <br> If there are multiple column expressions, put each one on its own line (including the first one), indented one level more than select. <br> If there is a `distinct` qualifier, put it on the same line as `select`. | [LT09](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT09), [LT10](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT10) | Yes | Yes |
 | Don't put extra spaces inside of parentheses | [LT01](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT01) | Yes | Yes |
 

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -27,6 +27,12 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 | Prefer union all to union| [AM02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM02) | N/A,<br>(not supported in snowflake)  | No |
 | Avoid using unnecessary table aliases, especially initialisms.<br> It's harder to understand what the table called "c" is <br>compared to "customers". | [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes | No |
 | Be explicit with all join types <br> for example use `inner join` instead of just `join`. | [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes | No |
+| Use single quotes for strings. | [CV10](https://docs.sqlfluff.com/en/stable/rules.html#rule-CV10) | Yes | No |
+| Don't use `using` in joins. | [ST07](https://docs.sqlfluff.com/en/stable/rules.html#rule-STO7) | Yes | No |
+| Start each CTE on its own line, Use a single blank line around CTEs to add visual separation | [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes | No |
+| Don't end a line with an operator like `and`, `or`, `+`, `||`, etc | [LT03](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT03) | Yes | Yes |
+| If there is only one column expression, put it on the same line as select. <br> If there are multiple column expressions, put each one on its own line (including the first one), indented one level more than select. <br> If there is a `distinct` qualifier, put it on the same line as `select`. | [LT09](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT09), [LT10](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT10) | Yes | Yes |
+| Don't put extra spaces inside of parentheses | [LT01](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT01) | Yes | Yes |
 
 
 ### Using the sqlfluff config in your project, please use the versions that are in the [requirements.txt](https://github.com/cdp-ucsc/dbt-pilot/blob/main/requirements.txt) e.g: 

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -1,0 +1,58 @@
+## SQLFluff
+
+### Background
+
+[UCSC Sql Style Guide](https://github.com/cdp-ucsc/dbt-pilot/wiki/Style-Guide-Draft#sql-style-guide)
+
+[Roles](https://towardsdatascience.com/sqlfluff-the-linter-for-modern-sql-8f89bd2e9117) of a linting tool are to enforce cosmetic rules and prevent code smells.
+> *"Code bases without a consistent style are hard to read and work with because of their unpredictable structure....
+Beyond “ugly” code, there is another category of “problematic” code. Code that isn’t invalid per say, but might indicate an issue in the logic." - Daniel Mateus Pires, Towards Data Science*
+
+Use [SQLFluff](https://docs.sqlfluff.com/en/stable/) to enforce these rules.
+
+SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT applications in mind, SQLFluff also works with Jinja templating and dbt. SQLFluff will auto-fix most linting errors, allowing you to focus your time on what matters.
+
+[Source Reference](https://github.com/sqlfluff/sqlfluff#readme)
+
+### The .sqlfluff config in this project enforces the below rules.
+
+| **SQL Style Guide Rule** | **Rule Code** | **SQLFluff Fix compatible** | **SQLFluff Default Configuration** |
+|:---|:---|:---|:---|
+| Use trailing commas | [LT04](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_LT04) | Yes | Yes |
+| Indents should be four spaces <br>(except for predicates, which should line up with the where keyword) | [LT02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_LT02) | Yes | Yes |
+| Lines of SQL should be no longer than 120 characters | max_line_length | Yes | No |
+| Use all lowercase unless a specific scenario needs you to do otherwise. <br>This means that keywords, field names, function names, and file names should all be lowercased. | [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01),<br> [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), <br> [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes | No |
+| Always use the `as` keyword when aliasing columns, expressions, and tables. | [AL01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL01), <br> [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02) | Yes | Yes |
+| Grouping by column numbers is preferred <br> over grouping by column names/aliases (eg. group by 1, 2) <br>Note that if you are grouping by more than a few columns, <br>it may be worth revisiting your model design. | [AM06](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM06) | No | No |
+| Prefer union all to union| [AM02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM02) | N/A,<br>(not supported in snowflake)  | No |
+| Avoid using unnecessary table aliases, especially initialisms.<br> It's harder to understand what the table called "c" is <br>compared to "customers". | [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes | No |
+| Be explicit with all join types <br> for example use `inner join` instead of just `join`. | [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes | No |
+
+
+### Using the sqlfluff config in your project, please use the versions that are in the [requirements.txt](https://github.com/cdp-ucsc/dbt-pilot/blob/main/requirements.txt) e.g: 
+
+- Install  SQLFluff
+`pip install sqlfluff==1.4.5`
+ 
+- Install adapter
+`pip install dbt-snowflake==1.3.0`
+
+- Install templater
+`pip install sqlfluff-templater-dbt==1.4.5`
+
+- there is a configured.sqlfluff in the root of the project.  
+it follows the dbt sql style guide as closely as possible (there are some rules that are not able to be linted or fixed)
+`.sqlfluff, .sqlfluffignore`
+
+#### cli examples:
+- lint a specific file
+`sqlfluff lint models/staging/fis/test_joins.sql`
+
+- lint all files in a directory
+`sqlfluff lint models/staging/fis`
+
+- sqlfluff fix a specific file (caution: this will make changes to your file)
+`sqlfluff fix models/staging/fis/test_joins.sql`
+
+- sqlfluff fix files in specific directory (caution: this will make changes to all files)<br>
+`sqlfluff fix models/staging/fis`

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -14,7 +14,7 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 
 [Source Reference](https://github.com/sqlfluff/sqlfluff#readme)
 
-### The .sqlfluff config in this project enforces the below rules.
+### SQLFLuff rules used in the .sqlfluff config in UCSC dbt project
 
 | **SQL Style Guide Rule** | **Rule Code** | **SQLFluff Fix compatible** | **SQLFluff Default Configuration** |
 |:---|:---|:---|:---|
@@ -36,30 +36,24 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 | Don't put extra spaces inside of parentheses | [LT01](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT01) | Yes | Yes |
 
 
-### Using the sqlfluff config in your project, please use the versions that are in the [requirements.txt](https://github.com/cdp-ucsc/dbt-pilot/blob/main/requirements.txt) e.g: 
+### How to use sqlfluff config in your project
+#### please use the versions that are in the [requirements.txt](https://github.com/cdp-ucsc/dbt-pilot/blob/main/requirements.txt) e.g: 
 
-- Install  SQLFluff
-`pip install sqlfluff==1.4.5`
- 
-- Install adapter
-`pip install dbt-snowflake==1.3.0`
+- Install  SQLFluff <br />
+`pip install -r requirements.txt `
 
-- Install templater
-`pip install sqlfluff-templater-dbt==1.4.5`
-
-- there is a configured.sqlfluff in the root of the project.  
-it follows the dbt sql style guide as closely as possible (there are some rules that are not able to be linted or fixed)
+- there is a configured .sqlfluff in the root of the project, which follows the dbt sql style guide as closely as possible (there are some rules that are not able to be fixed) <br />
 `.sqlfluff, .sqlfluffignore`
 
 #### cli examples:
-- lint a specific file
-`sqlfluff lint models/staging/fis/test_joins.sql`
+- lint a specific file<br />
+`sqlfluff lint models/staging/setl/stg_dwh__setl_step_log.sql`
 
-- lint all files in a directory
-`sqlfluff lint models/staging/fis`
+- lint all files in a directory<br />
+`sqlfluff lint models/staging/setl`
 
-- sqlfluff fix a specific file (caution: this will make changes to your file)
-`sqlfluff fix models/staging/fis/test_joins.sql`
+- sqlfluff fix a specific file (caution: this will make changes to your file)<br />
+`sqlfluff fix models/staging/setl/stg_dwh__setl_step_log.sql`
 
-- sqlfluff fix files in specific directory (caution: this will make changes to all files)
-`sqlfluff fix models/staging/fis`
+- sqlfluff fix files in specific directory (caution: this will make changes to all files)<br />
+`sqlfluff fix models/staging/setl`

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -1,4 +1,4 @@
-## SQLFluff
+# SQLFluff
 
 ### Background
 

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -2,7 +2,7 @@
 
 ### Background
 
-[UCSC Sql Style Guide](https://github.com/cdp-ucsc/dbt-pilot/wiki/Style-Guide-Draft#sql-style-guide)
+[UCSC Sql Style Guide](https://cdp-ucsc.github.io/doc/docs/project_resources/sql_style_guide)
 
 [Roles](https://towardsdatascience.com/sqlfluff-the-linter-for-modern-sql-8f89bd2e9117) of a linting tool are to enforce cosmetic rules and prevent code smells.
 > *"Code bases without a consistent style are hard to read and work with because of their unpredictable structure....
@@ -27,6 +27,7 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 | Prefer union all to union| [AM02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM02) | N/A,<br>(not supported in snowflake)  | No |
 | Avoid using unnecessary table aliases, especially initialisms.<br> It's harder to understand what the table called "c" is <br>compared to "customers". | [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes | No |
 | Be explicit with all join types <br> for example use `inner join` instead of just `join`. | [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes | No |
+| When joining multiple tables, always prefix the column names with the table name | [RF02](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | No | Yes |
 | Use single quotes for strings. | [CV10](https://docs.sqlfluff.com/en/stable/rules.html#rule-CV10) | Yes | No |
 | Don't use `using` in joins. | [ST07](https://docs.sqlfluff.com/en/stable/rules.html#rule-STO7) | Yes | No |
 | Start each CTE on its own line, Use a single blank line around CTEs to add visual separation | [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes | No |

--- a/cdp-docs/docs/project_resources/sqlfluff.md
+++ b/cdp-docs/docs/project_resources/sqlfluff.md
@@ -2,7 +2,7 @@
 
 ### Background
 
-[UCSC Sql Style Guide](https://cdp-ucsc.github.io/doc/docs/project_resources/sql_style_guide)
+[UCSC SQL Style Guide](https://cdp-ucsc.github.io/doc/docs/project_resources/sql_style_guide)
 
 [Roles](https://towardsdatascience.com/sqlfluff-the-linter-for-modern-sql-8f89bd2e9117) of a linting tool are to enforce cosmetic rules and prevent code smells.
 > *"Code bases without a consistent style are hard to read and work with because of their unpredictable structure....
@@ -19,20 +19,20 @@ SQLFluff is a dialect-flexible and configurable SQL linter. Designed with ELT ap
 | **SQL Style Guide Rule** | **Rule Code** | **SQLFluff Fix compatible** | **SQLFluff Default Configuration** |
 |:---|:---|:---|:---|
 | Use trailing commas | [LT04](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_LT04) | Yes | Yes |
-| Indents should be four spaces <br>(except for predicates, which should line up with the where keyword) | [LT02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_LT02) | Yes | Yes |
+| Indents should be four spaces <br />(except for predicates, which should line up with the where keyword) | [LT02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_LT02) | Yes | Yes |
 | Lines of SQL should be no longer than 120 characters | max_line_length | Yes | No |
-| Use all lowercase unless a specific scenario needs you to do otherwise. <br>This means that keywords, field names, function names, and file names should all be lowercased. | [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01),<br> [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), <br> [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes | No |
-| Always use the `as` keyword when aliasing columns, expressions, and tables. | [AL01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL01), <br> [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02) | Yes | Yes |
-| Grouping by column numbers is preferred <br> over grouping by column names/aliases (eg. group by 1, 2) <br>Note that if you are grouping by more than a few columns, <br>it may be worth revisiting your model design. | [AM06](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM06) | No | No |
-| Prefer union all to union| [AM02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM02) | N/A,<br>(not supported in snowflake)  | No |
-| Avoid using unnecessary table aliases, especially initialisms.<br> It's harder to understand what the table called "c" is <br>compared to "customers". | [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes | No |
-| Be explicit with all join types <br> for example use `inner join` instead of just `join`. | [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes | No |
+| Use all lowercase unless a specific scenario needs you to do otherwise. <br />This means that keywords, field names, function names, and file names should all be lowercased. | [CP01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP01),<br /> [CP02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP02), <br /> [CP03](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CP03) | Yes | No |
+| Always use the `as` keyword when aliasing columns, expressions, and tables. | [AL01](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL01), <br /> [AL02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL02) | Yes | Yes |
+| Grouping by column numbers is preferred <br /> over grouping by column names/aliases (eg. group by 1, 2) <br />Note that if you are grouping by more than a few columns, <br />it may be worth revisiting your model design. | [AM06](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM06) | No | No |
+| Prefer union all to union| [AM02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AM02) | N/A,<br />(not supported in snowflake)  | No |
+| Avoid using unnecessary table aliases, especially initialisms.<br /> It's harder to understand what the table called "c" is <br />compared to "customers". | [AL07](https://docs.sqlfluff.com/en/stable/rules.html#rule-AL07) | Yes | No |
+| Be explicit with all join types <br /> for example use `inner join` instead of just `join`. | [AM05](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | Yes | No |
 | When joining multiple tables, always prefix the column names with the table name | [RF02](https://docs.sqlfluff.com/en/stable/rules.html#rule-AM05) | No | Yes |
 | Use single quotes for strings. | [CV10](https://docs.sqlfluff.com/en/stable/rules.html#rule-CV10) | Yes | No |
 | Don't use `using` in joins. | [ST07](https://docs.sqlfluff.com/en/stable/rules.html#rule-STO7) | Yes | No |
-| Start each CTE on its own line, Use a single blank line around CTEs to add visual separation | [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes | No |
+| Start each CTE on its own line, Use a single blank line around CTEs to add visual separation | [LT07](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT07), <br /> [LT08](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT08) | Yes | No |
 | Don't end a line with an operator like `and`, `or`, `+`, <code>&vert;&vert;</code> etc | [LT03](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT03) | Yes | Yes |
-| If there is only one column expression, put it on the same line as select. <br> If there are multiple column expressions, put each one on its own line (including the first one), indented one level more than select. <br> If there is a `distinct` qualifier, put it on the same line as `select`. | [LT09](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT09), [LT10](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT10) | Yes | Yes |
+| If there is only one column expression, put it on the same line as select. <br /> If there are multiple column expressions, put each one on its own line (including the first one), indented one level more than select. <br /> If there is a `distinct` qualifier, put it on the same line as `select`. | [LT09](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT09), [LT10](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT10) | Yes | Yes |
 | Don't put extra spaces inside of parentheses | [LT01](https://docs.sqlfluff.com/en/stable/rules.html#rule-LT01) | Yes | Yes |
 
 
@@ -61,5 +61,5 @@ it follows the dbt sql style guide as closely as possible (there are some rules 
 - sqlfluff fix a specific file (caution: this will make changes to your file)
 `sqlfluff fix models/staging/fis/test_joins.sql`
 
-- sqlfluff fix files in specific directory (caution: this will make changes to all files)<br>
+- sqlfluff fix files in specific directory (caution: this will make changes to all files)
 `sqlfluff fix models/staging/fis`

--- a/cdp-docs/package-lock.json
+++ b/cdp-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cdp-docs",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Description & motivation:
Enhancements to UCSC Style guide and SQLFluff upgrade included more rules we are interested in linting and fixing. 
Changes to Sql Style Guide to include the corresponding sqlfluff rules
New SQLFluff documentation to include sql style guide rules 

## To-do before merge:
n/a

## Screenshots:
n/a

## References or links:
issue #4, #15, and https://github.com/cdp-ucsc/dbt-pilot/issues/66, https://github.com/cdp-ucsc/dbt-pilot/issues/102

## Validation of models:
n/a

## Checklist:
- [x] I filled out my PR.
- [x] I assigned a reviewer(s) to my PR.
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [ ] My SQL follows the [UCSC Style Guide (wip-draft)](https://github.com/cdp-ucsc/dbt-pilot/wiki/Style-Guide-Draft).
- [ ] I have materialized my models appropriately.
- [ ] I have added appropriate tests and documentation to any new models.
- [ ] I have updated the README file.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204585020717576