### PR TITLE
Add skeleton of enterprise modeling guide section

### DIFF
--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/_category_.json
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/_category_.json
@@ -1,0 +1,9 @@
+{
+    "label": "Enterprise Modeling Guides",
+    "position": 1,
+    "link": {
+      "type": "generated-index",
+      "description": "Documentation for CDP's enterprise dimensional modeling."
+    }
+  }
+  

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
@@ -1,0 +1,21 @@
+---
+description: Documentation for CDP's multi-project structure using dbt mesh.
+sidebar_position: 1
+---
+
+# dbt Mesh Modeling Guide
+
+### Project Types
+
+#### I. dbt Projects
+  - Core Domain Projects
+  - "Sub" Projects (projects that ref the core projects) 
+  
+#### II. Other Projects
+  - Utility (like shared macros project)
+
+---
+
+How do different projects interact?
+
+Contracts?

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
@@ -5,6 +5,12 @@ sidebar_position: 2
 
 # dbt Mesh Modeling Guide
 
+:::caution
+
+This page is a work in progress. Currently this page is a placeholder for a future guide. This guide may be reorganized and incorporated into a different guide in the future. 
+
+:::
+
 ### Project Types
 
 #### I. dbt Projects

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_mesh_modeling_guide.md
@@ -1,6 +1,6 @@
 ---
 description: Documentation for CDP's multi-project structure using dbt mesh.
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # dbt Mesh Modeling Guide

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -1,15 +1,20 @@
 ---
 description: Documentation for CDP's individual dbt projects.
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # dbt Project Modeling Guide
+
+:::caution
+
+This page is a work in progress
+
+:::
 
 # Project Structure and Guide
 ```
 └─── dbt_project_name
      ├─── .github
-     ├─── .vscode
      ├─── analyses
      ├─── data
      ├─── dbt_packages
@@ -25,50 +30,88 @@ sidebar_position: 2
      ├─── seeds
      ├─── snapshots
      ├─── target
+     ├─── template
      ├─── tests
      ├─── .gitignore
+     ├─── .sqlfluff
      ├─── .sqlfluffignore
      ├─── dbt_project.yml
      ├─── packages.yml
      ├─── README.md
      └─── requirements.txt
 ```
+The naming convention of projects are:
+```bash
+[project]-analytics
+```
+
+For example, the financial domain project is named `financial-analytics`.
+
 ## dbt_project_name/
+### Template Repo
 ```
 └─── dbt_project_name
      ├─── .github
-     ├─── .vscode
-     .
-     .
-     .
+     ├─── ...
+     ├─── template
+     ├─── ...
      ├─── .gitignore
+     ├─── .sqlfluff
      ├─── .sqlfluffignore
-     ├─── dbt_project.yml
+     ├─── ...
      ├─── packages.yml
      ├─── README.md
      └─── requirements.txt
 ```
-Comments on the stand alone files.
+The selected resources above are managed by the template repo, [dbt-project-template](https://github.com/cdp-ucsc/dbt-project-template). Therefore, the resources shared by all of the dbt projects are centrally managed. All dbt projects are created from the template repo.
 
-### Project Properties and Configurations (YAMLs)
+### dbt Project
 ```
 └─── dbt_project_name
+     ├─── ...
+     ├─── analyses
+     ├─── data
+     ├─── dbt_packages
+     ├─── logs
+     ├─── macros
+     ├─── models
+     │    ├─── base
+     │    ├─── intermediate
+     │    ├─── legacy
+     │    ├─── marts
+     │    ├─── reports
+     │    └─── staging
+     ├─── seeds
+     ├─── snapshots
+     ├─── target
+     ├─── ...
+     ├─── tests
+     ├─── ...
+     ├─── dbt_project.yml
+     ├─── ...
+```
+The remaining resources are project specific and are not managed by the template repo.
+
+### Different Project Properties and Configurations (YAMLs)
+```
+└─── dbt_project_name
+     ├─── ...
      ├─── models
      │    ├─── ...
-     │    └─── │    ├─── properties.yml
-               ├─── ...
+     │    ├─── │    ├─── properties.yml
+     │    ├─── ...
      ├─── ...
      ├─── dbt_project.yml
      ├─── packages.yml
      ├─── ...
 ```
-A dbt project uses YAML, `.yml`, files to store and specify properties and configurations for different project resources. dbt Labs has documentation regarding properties and configurations [here](https://docs.getdbt.com/reference/configs-and-properties). 
+A dbt project uses YAML, `.yml`, files to store and specify properties and configurations for project resources and the project itself. dbt Labs has documentation regarding properties and configurations [here](https://docs.getdbt.com/reference/configs-and-properties).
 >Note that dbt Lab's documentation is versioned and to select the correct version when reviewing their documentation.
 
-The YAMLs that can be found in a dbt project are `dbt_project.yml`, `packages.yml`, and `properties.yml`.
+The different type of YAMLs that can be found in a dbt project are `dbt_project.yml`, `packages.yml`, and `properties.yml`.
 
-#### DBT_PROJECT.YML
-dbt Labs' project configuration documentation for the `dbt_project.yml` can be found [here](https://docs.getdbt.com/reference/dbt_project.yml). CDP projects usually use the [`dbt_project.yml`](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/include/starter_project/dbt_project.yml) that is generated during the `dbt init` process with minimal initial modifications. A common area that may receive modifications later on is the models section. For example,
+#### dbt_project.yml
+dbt Labs' project configuration documentation for the `dbt_project.yml` can be found [here](https://docs.getdbt.com/reference/dbt_project.yml). CDP projects use the [`dbt_project.yml`](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/include/starter_project/dbt_project.yml) that is generated during the `dbt init` process and make modifications as necessary. A common area that may receive modifications is the models section. For example,
 ```yml
 # In this example config, we tell dbt to build all models in the example/
 # directory as views. These settings can be overridden in the individual model
@@ -81,45 +124,36 @@ models:
       +materialized: view
     marts:
       +materialized: table
-    validation:
-      +materialized: table
-      +schema: validation
     reverse_etl:
       +materialized: table
       +schema: shared_data
 ```
+There is only one `dbt_project.yml` in a dbt project.
 
-#### PACKAGES.YML
+#### packages.yml
+The `packages.yml` is where packages that should be made available for use in the dbt project are specified. There is only one `packages.yml` in a dbt project. Note that the `packages.yml` is managed by the template repo. 
 
-#### PROPERTIES.YML
-Property YAML files can be named anything. What identifies a YAML file as a property YAML is the resource key and the property keys and values that follow. The following project resources can have property YAML files: models, seeds, snapshots, sources, analyses, exposures, and macros. The [dbt Labs documentation](https://docs.getdbt.com/reference/configs-and-properties) on properties and configurations is very thorough and highly recommended for developers to review. 
+#### properties.yml
+Property YAML files can be named anything. What identifies a YAML file as a property YAML is the resource key and the property keys and values that follow. The following project resources can have property YAML files: models, seeds, snapshots, sources, analyses, exposures, and macros. There can be multiple `properties.yml` files in a dbt project. The [dbt Labs documentation](https://docs.getdbt.com/reference/configs-and-properties) on properties and configurations is very thorough and highly recommended for developers to review.
 
 This document will build upon dbt Labs documentation and further discuss specific CDP standards for each project resource in its corresponding section.
 
 ## dbt_project_name/analyses/
+> Documentation needed.
 
 ## dbt_project_name/data/
+> Documentation needed.
 
 ## dbt_project_name/dbt_packages/
+> Documentation needed.
 
 ## dbt_project_name/logs/
+> Documentation needed.
 
 ## dbt_project_name/macros/
-- Description of the `macros` folder
+> Documentation needed.
 
 ## dbt_project_name/models/
-### Model Properties and Configurations (YAMLs)
-The use of the [`sources:`](https://docs.getdbt.com/reference/source-properties) and [`models:`](https://docs.getdbt.com/reference/model-properties) keys in a YAML file specify the file as a model property file (rather than a seeds or macro property file).
-
-The naming convention for model property YAMLs:
-```bash
-_[model_type]_[source_name]__[resource_type].yml
-```
-where
-- model_type is base, int (intermediate), lgc (legacy), mart (marts), rpt (reports), or stg (staging)
-- source_name is the source name
-- resource_type is source or model.
-
 ### Modeling Best Practices
 - The general naming convention for all models and fields should be singular.
 > - If you had a dimension that held attributes for a student in a given term, would you call it “dim_student_term”, “dim_student_terms”, or “dim_students_terms”?
@@ -131,7 +165,7 @@ where
 > - [Analytics Engineering Glossary: CTE in SQL](https://docs.getdbt.com/terms/cte)
 > - ['Import' CTEs](https://docs.getdbt.com/best-practices/how-we-style/2-how-we-style-our-sql#import-ctes) vs ['Functional' CTEs](https://docs.getdbt.com/best-practices/how-we-style/2-how-we-style-our-sql#functional-ctes)
 > - [Why dbt Labs (Fishtown) SQL style guide uses so many CTEs](https://discourse.getdbt.com/t/why-the-fishtown-sql-style-guide-uses-so-many-ctes/1091)
-> - [Different examples of CDP models]
+> - [Add CDP example models]
 - Developers should prioritize modular, reusable, concise, and universal modeling.
 > - Again, CTEs can be used to create modular and concise modeling.
 > - Intermediate models can be used to create modular, reusable, and concise models.
@@ -142,7 +176,6 @@ where
 └─── dbt_project_name
      ├─── ...
      ├─── models
-     │    ├─── ...
      │    └─── base
                ├─── source1
                │    ├─── _base_source1__sources.yml
@@ -150,14 +183,15 @@ where
                │    ├─── base_source1__model1.sql
                │    ├─── ...
                │    └─── base_source1__modeln.yml
-               ├─── ...
+               ├─── ....
                └─── sourcen
+     │    ├─── ...
      ├─── ...
 
 ```
 The base layer should be organized by source. Each base folder should contain a source yaml, model yaml, and base models.
 
-#### Best Practices
+#### BEST PRACTICES
 - The base layer should only be used on a case by case basis.
 - The base layer should be the landing zone for semi-structure source data that needs to be parsed. (e.g. JSON data)
 - The base layer should be `ref()` in the staging layer.
@@ -186,7 +220,7 @@ The base layer should be organized by source. Each base folder should contain a 
      ├─── ...
      ├─── models
      │    ├─── ...
-     │    └─── staging
+     │    ├─── staging
                ├─── source1
                │    ├─── _stg_source1__source.yml
                │    ├─── _stg_source1__model.yml
@@ -194,26 +228,33 @@ The base layer should be organized by source. Each base folder should contain a 
                │    ├─── ...
                │    └─── stg_source1__modeln.yml
                ├─── source2
-               │    ├─── _stg_source2__source.yml
+               │    ├─── _stg_source2__schemaX_source.yml
+               │    ├─── _stg_source2__schemaY_source.yml
+               │    ├─── _stg_source2__schemaZ_source.yml
                │    ├─── _stg_source2__model.yml
                │    ├─── stg_source2__model1.sql
                │    ├─── ...
                │    └─── stg_source2__modeln.yml
                ├─── ...
-               └─── sourcen
+     │    ├─── ...
      ├─── ...
-
 ```
-The staging layer is organized by source. Each source folder should contain one property YAML for source, one property YAML for model, and the staging models itself.
+The staging layer is organized by source. A source can be further organized into separate source YAMLs for each schema if the source is comprised of multiple schemas. A single source will have a single model YAML regardless of the organization of source YAMLs.
 
-#### NAMING CONVENTIONS
-Property YAMLs:
+See the `financial-analytics` [staging layer](https://github.com/cdp-ucsc/financial-analytics/tree/main/models/staging/) for an example.
+
+#### RESOURCE NAMING CONVENTION
+Source Property YAML:
 ```
-_stg_[source]__source.yml
+_stg_[source]__source.yml or `_stg_[source]__[schema]_source.yml
+```
+
+Model Property YAML:
+```
 _stg_[source]__model.yml
 ```
 
-Staging models:
+Staging Model:
 ```
  stg_[source]__[source_table_name].sql
 ```
@@ -222,24 +263,24 @@ Staging models:
 ```yml
 version: 2
 sources:
-  - name:
-    description:
-    loader:
-    database:
-    schema:
-    tables:
-      - name:
-        description:
-        meta:
-          contains_pii: <TRUE/FALSE>
-          effective_dated: <TRUE/FALSE>
-          partition_columns: ["column1", "column2", ...]
-        columns:
-          - name:
-            meta:
-              alias:
+    - name: source_name
+      meta:
+        soft_delete_columns:
+      tables:
+        - name: table_name
+          meta:
+            effective_type:
+            effective_date_col:
+            effective_sequence_col:
+            effective_sequence_order:
+            partition_columns:
+            columns:
+              - name: column_a
+                meta:
+                  casted_as: data_type
+                  renamed_as: new_name
 ```
-All sources at the staging layer must declare the above meta keys.
+CDP utilizes the source YAML as per dbt lab's documentation. CDP also utilizes dbt's meta tag to declare additional information specific to CDP's staging process. Further information can be found [here](https://github.com/cdp-ucsc/cdp-ucsc-dbt-codegen/tree/staging-layer-macros/macros/cdp-ucsc-staging-layer).
 
 #### MODEL.YML
 ```yml
@@ -260,20 +301,10 @@ All models at the staging layer must be tested for uniqueness and emptyness usin
 
 #### STAGING MODEL BEST PRACTICES
 - All models in the stager layer should be materialized as a view.
-- The staging layer should be generated using the domain and source specific staging macro.
-  - [More info on staging macros]
-  - If the model is SCD2, then the final data set should include `valid_from`, `valid_to`, `current_rcd_desc`, and `is_current_record` fields
-  - The staging layer should almost always exclude deleted records.
-    - [More info regarding different conditions based on source systems]
-- If a base model exists, the staging model should `ref()` the base model.
-
-#### STAGING MODEL MACROS
-Inspired by [codegen](https://hub.getdbt.com/dbt-labs/codegen/latest/), CDP uses macros and bash scripts to automate the creation of the staging layer. CDP uses source specific macros and so not all staging macros are identical. The advantages of the staging macros are:
-- reducing repetitive manual work with an automated process
-- achieving consist style and structure across multiple sources and projects at the staging layer
-- sharing foundational SCD2 logic at the staging layer
-
-[How to generate a staging layer with the use of macros]
+- [CDP's staging macros](https://github.com/cdp-ucsc/cdp-ucsc-dbt-codegen/tree/staging-layer-macros/macros/cdp-ucsc-staging-layer) should be used to generate models.
+  - By utilizing CDP's staging macros, staging logic will be consistently managed across all of the dbt projects. 
+  - If a base model exists, the staging model should `ref()` the base model and should not be generated from CDP's staging macros.
+- Renames at the staging layer should be independent from business names/logic. Business friendly names can be declared in downstream layers.
 
 ## dbt_project_name/seeds/
 - Description of the `seeds` folder

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -1,4 +1,9 @@
-# Modeling Guide
+---
+description: Documentation for CDP's individual dbt projects.
+sidebar_position: 2
+---
+
+# dbt Project Modeling Guide
 
 # Project Structure and Guide
 ```
@@ -28,6 +33,30 @@
      ├─── README.md
      └─── requirements.txt
 ```
+## dbt_project_name/
+```
+└─── dbt_project_name
+     ├─── .github
+     ├─── .vscode
+     .
+     .
+     .
+     ├─── .gitignore
+     ├─── .sqlfluffignore
+     ├─── dbt_project.yml
+     ├─── packages.yml
+     ├─── README.md
+     └─── requirements.txt
+```
+Comments on the stand alone files.
+
+## dbt_project_name/analyses/
+
+## dbt_project_name/data/
+
+## dbt_project_name/dbt_packages/
+
+## dbt_project_name/logs/
 
 ## dbt_project_name/macros/
 - Description of the `macros` folder
@@ -39,7 +68,10 @@
 > - Coding Principals – in coding, entities are always singular (e.g., Public Class Inventory)
 > - English Language Learners – pluralization is difficult, e.g., “inventory” vs “inventories”
 - All models should be documented and tested.
-- All model table documentation should utilize doc blocks. 
+
+#### Model Documentation of `source.yml` and `model.yml`
+- All model documentation should utilize doc blocks.
+- **Should we organize using a subfolder?** Things can get really messy if we want to document down to the columns. And using doc blocks. Or we should just have one .yml for each model.
 
 ### models/base/
 ```
@@ -200,10 +232,7 @@ _stg_[source]__sources_effdt.yml
 ## dbt_project_name/snapshots/
 - Description of the `snapshots` folder
 
+## dbt_project_name/target/
+
 ## dbt_project_name/tests/
 - Description of the `tests` folder
-
-## Common Modeling Topics
-### Optimizing query times with CTEs
-### Parsing semi-structured data
-### Joining SCD2 tables

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -208,7 +208,80 @@ The base layer should be organized by source. Each base folder should contain a 
 > Documentation needed.
 
 ### models/reverse_etl/
-> Documentation needed.
+```
+└─── dbt_project_name
+     ├─── ...
+     ├─── models
+     │    ├─── ...
+     │    ├─── reverse_etl
+               ├─── destination_system1
+               │    ├─── _retl_destination_system1_exposure.yml
+               │    ├─── _retl_destination_system1_model.yml
+               │    ├─── retl_destination_system1__model1.sql
+               │    ├─── retl_destination_system1__model2.sql
+               │    ├─── ...
+               │    └─── retl_destination_system1__modeln.sql
+               ├─── destination_system2
+               │    ├─── ...
+               ├─── ...
+     │    ├─── ...
+     ├─── ...
+```
+The reverse etl layer is organized by destination systems. Each destination system will have a model YAML and exposure YAML.
+
+#### RESOURCE NAMING CONVENTION
+Model Property YAML:
+```
+_retl_[destination_system]_model.yml
+```
+
+Exposure Property YAML:
+```
+_retl_[destination_system]_exposure.yml
+```
+
+Reverse ETL Model:
+```
+retl_[destination_system]__[model_name].sql
+```
+
+#### MODEL.YML
+```yml
+version: 2
+models:
+  - name:
+    description: 
+```
+There is no set of standard tests recommended for reverse etl models. Suggested tests are tests related to data integrity/formatting required by the reverse etl tool Census and the destination system.
+
+The model descriptions should detail the business requirements that the model is meeting for the specific destination system.
+
+See more model properties [here](https://docs.getdbt.com/reference/model-properties).
+
+#### EXPOSURE.YML
+```yml
+version: 2
+exposures:
+  - name:
+    label:
+    description:
+    type:
+    maturity:
+    depends_on:
+    tags:
+    owner:
+      name:
+      email: 
+```
+All reverse etl models should be referenced under an exposure's `depends_on` key. Exposures are important to surface the destination system in the project DAG. 
+
+See more exposure properties [here](https://docs.getdbt.com/reference/exposure-properties).
+
+#### REVERSE ETL MODEL BEST PRACTICES
+- Ideally models are not directly referencing staging models and are referencing mart models.
+  - Beware of models referencing resources of different materializations (i.e. view vs table).
+- Keep in mind the reverse etl layer is intended to extract business requirements/logic out of the reverse etl tool and manage it in the dbt project.
+  - Reverse etl tools can change. Managing the business requirements in the dbt project makes it easily transferrable. The dbt project also provides version management that is already integrated with CDP's workflow.
 
 ### models/staging/
 ```
@@ -278,6 +351,8 @@ sources:
 ```
 CDP utilizes the source YAML as per dbt lab's documentation. CDP also utilizes dbt's meta tag to declare additional information specific to CDP's staging process. Further information can be found [here](https://github.com/cdp-ucsc/cdp-ucsc-dbt-codegen/tree/staging-layer-macros/macros/cdp-ucsc-staging-layer).
 
+See more source properties [here](https://docs.getdbt.com/reference/source-properties).
+
 #### MODEL.YML
 ```yml
 version: 2
@@ -294,6 +369,8 @@ models:
           min_value: 1
 ```
 All models at the staging layer must be tested for uniqueness and emptyness using the above tests.
+
+See more model properties [here](https://docs.getdbt.com/reference/model-properties).
 
 #### STAGING MODEL BEST PRACTICES
 - All models in the stager layer should be materialized as a view.

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -154,7 +154,7 @@ This document will build upon dbt Labs documentation and further discuss specifi
 > Documentation needed.
 
 ## dbt_project_name/models/
-### Modeling Best Practices
+### Model Best Practices
 - The general naming convention for all models and fields should be singular.
 > - If you had a dimension that held attributes for a student in a given term, would you call it “dim_student_term”, “dim_student_terms”, or “dim_students_terms”?
 > - Simplicity – singular is shorter and doesn’t vary based on word (e.g., “ies”, “es”, “s”)
@@ -199,20 +199,16 @@ The base layer should be organized by source. Each base folder should contain a 
 - The base models should be materialized as a view.
 
 ### models/intermediate/
-- Description of the `intermediate` folder
-- Best practices of `intermediate` folder
-  
+> Documentation needed.er
+
 ### models/legacy/
-- Description of the `legacy` folder
-- Best practices of `base` folder
+> Documentation needed.
 
 ### models/marts/
-- Description of the `marts` folder
-- Best practices of `marts` folder
+> Documentation needed.
 
-### models/reports/
-- Description of the `reports` folder
-- Best practices of `reports` folder
+### models/reverse_etl/
+> Documentation needed.
 
 ### models/staging/
 ```
@@ -307,12 +303,13 @@ All models at the staging layer must be tested for uniqueness and emptyness usin
 - Renames at the staging layer should be independent from business names/logic. Business friendly names can be declared in downstream layers.
 
 ## dbt_project_name/seeds/
-- Description of the `seeds` folder
+> Documentation needed.
 
 ## dbt_project_name/snapshots/
-- Description of the `snapshots` folder
+> Documentation needed.
 
 ## dbt_project_name/target/
+> Documentation needed.
 
 ## dbt_project_name/tests/
-- Description of the `tests` folder
+> Documentation needed.

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -229,11 +229,15 @@ sources:
     schema:
     tables:
       - name:
-        description: 
+        description:
         meta:
           contains_pii: <TRUE/FALSE>
           effective_dated: <TRUE/FALSE>
           partition_columns: ["column1", "column2", ...]
+        columns:
+          - name:
+            meta:
+              alias:
 ```
 All sources at the staging layer must declare the above meta keys.
 

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/dbt_project_modeling_guide.md
@@ -178,8 +178,8 @@ This document will build upon dbt Labs documentation and further discuss specifi
      ├─── models
      │    └─── base
                ├─── source1
-               │    ├─── _base_source1__sources.yml
-               │    ├─── _base_source1__models.yml
+               │    ├─── _base_source1__source.yml
+               │    ├─── _base_source1__model.yml
                │    ├─── base_source1__model1.sql
                │    ├─── ...
                │    └─── base_source1__modeln.yml
@@ -191,11 +191,29 @@ This document will build upon dbt Labs documentation and further discuss specifi
 ```
 The base layer should be organized by source. Each base folder should contain a source yaml, model yaml, and base models.
 
+#### RESOURCE NAMING CONVENTION
+Source Property YAML:
+```
+_base_[source]__source.yml
+```
+
+Model Property YAML:
+```
+_base_[source]__model.yml
+```
+
+Base Model:
+```
+base_[source]__model.sql
+```
+
 #### BEST PRACTICES
 - The base layer should only be used on a case by case basis.
-- The base layer should be the landing zone for semi-structure source data that needs to be parsed. (e.g. JSON data)
-- The base layer should be `ref()` in the staging layer.
-- The base layer should be used if there is a need for a model to retain the deleted records that are usually excluded in the staging layer. (e.g. `_fivetran_deleted = false`)
+- The base layer should be used as the landing zone for semi-structure source data that needs to be parsed. (e.g. JSON data)
+- The base layer can be used if there is a need for a model to retain the deleted records that are excluded in the staging layer. (e.g. `_fivetran_deleted = false`)
+  > This is a rare case. Double-check if this is the correct approach or `dbt snapshot` should be used.
+- The base layer should be `ref()` in the staging layer. 
+  > The staging layer model name should end in `_flattened` if the base model was semi-structured data.
 - The base models should be materialized as a view.
 
 ### models/intermediate/

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_modeling_topics.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_modeling_topics.md
@@ -1,0 +1,11 @@
+---
+description: Documentation for other modeling topics applicable to CDP.
+sidebar_position: 3
+---
+
+# Other Modeling Topics
+
+## Common Modeling Topics
+### Optimizing query times with CTEs
+### Parsing semi-structured data
+### Joining SCD2 tables

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_modeling_topics.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_modeling_topics.md
@@ -5,6 +5,12 @@ sidebar_position: 3
 
 # Other Modeling Topics
 
+:::caution
+
+This page is a work in progress. Currently this page is a placeholder for a future guide. This guide may be reorganized and incorporated into a different guide in the future. 
+
+:::
+
 ## Common Modeling Topics
 ### Optimizing query times with CTEs
 ### Parsing semi-structured data

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_projects.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_projects.md
@@ -5,5 +5,11 @@ sidebar_position: 4
 
 # Other Projects
 
+:::caution
+
+This page is a work in progress. Currently this page is a placeholder for a future guide. This guide may be reorganized and incorporated into a different guide in the future. 
+
+:::
+
 ## Utility Projects
 ### Reuseable Macros

--- a/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_projects.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/enterprise_modeling_guide/other_projects.md
@@ -1,0 +1,9 @@
+---
+description: Documentation for CDP's non-data/non-dbt projects.
+sidebar_position: 4
+---
+
+# Other Projects
+
+## Utility Projects
+### Reuseable Macros

--- a/cdp-docs/docs/program_overview/practitioner/guides/modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/modeling_guide.md
@@ -1,0 +1,206 @@
+# Modeling Guide
+
+# Project Structure and Guide
+```
+└─── dbt_project_name
+     ├─── .github
+     ├─── .vscode
+     ├─── analyses
+     ├─── data
+     ├─── dbt_packages
+     ├─── logs
+     ├─── macros
+     ├─── models
+     │    ├─── base
+     │    ├─── intermediate
+     │    ├─── legacy
+     │    ├─── marts
+     │    ├─── reports
+     │    └─── staging
+     ├─── seeds
+     ├─── snapshots
+     ├─── target
+     ├─── tests
+     ├─── .gitignore
+     ├─── .sqlfluffignore
+     ├─── dbt_project.yml
+     ├─── packages.yml
+     ├─── README.md
+     └─── requirements.txt
+```
+
+## dbt_project_name/macros/
+- Description of the `macros` folder
+
+## dbt_project_name/models/
+- The general naming convention for all models should be singular. 
+> - If you had a dimension that held attributes for a student in a given term, would you call it “dim_student_term”, “dim_student_terms”, or “dim_students_terms”?
+> - Simplicity – singular is shorter and doesn’t vary based on word (e.g., “ies”, “es”, “s”)
+> - Coding Principals – in coding, entities are always singular (e.g., Public Class Inventory)
+> - English Language Learners – pluralization is difficult, e.g., “inventory” vs “inventories”
+- All models should be documented and tested.
+- All model table documentation should utilize doc blocks. 
+
+### models/base/
+```
+└─── dbt_project_name
+     ├─── ...
+     ├─── models
+     │    ├─── ...
+     │    └─── base
+               ├─── source1
+               │    ├─── _base_source1__sources.yml
+               │    ├─── _base_source1__models.yml
+               │    ├─── base_source1__model1.sql
+               │    ├─── ...
+               │    └─── base_source1__modeln.yml
+               ├─── ...
+               └─── sourcen
+     ├─── ...
+
+```
+The base layer should be organized by source. Each base folder should contain a source yaml, model yaml, and base models.
+
+#### Best Practices
+- The base layer should only be used on a case by case basis. 
+- The base layer should be the landing zone for semi-structure source data that needs to be parsed. (e.g. JSON data)
+- The base layer should be `ref()` in the staging layer.
+- The base layer should be used if there is a need for a model to retain the deleted records that are usually excluded in the staging layer. (e.g. `_fivetran_deleted = false`)
+- The base models should be materialized as a view.
+
+### models/intermediate/
+- Description of the `intermediate` folder
+- Best practices of `intermediate` folder
+  
+### models/legacy/
+- Description of the `legacy` folder
+- Best practices of `base` folder
+
+### models/marts/
+- Description of the `marts` folder
+- Best practices of `marts` folder
+
+### models/reports/
+- Description of the `reports` folder
+- Best practices of `reports` folder
+
+### models/staging/
+```
+└─── dbt_project_name
+     ├─── ...
+     ├─── models
+     │    ├─── ...
+     │    └─── staging
+               ├─── source1
+               │    ├─── _stg_source1__sources.yml
+               │    ├─── _stg_source1__models.yml
+               │    ├─── stg_source1__model1.sql
+               │    ├─── ...
+               │    └─── stg_source1__modeln.yml
+               ├─── source2
+               │    ├─── _stg_source2__sources.yml
+               │    ├─── _stg_source2__sources_effdt.yml
+               │    ├─── _stg_source2__models.yml
+               │    ├─── stg_source2__model1.sql
+               │    ├─── ...
+               │    └─── stg_source2__modeln.yml
+               ├─── ...
+               └─── sourcen
+     ├─── ...
+
+```
+The staging layer should organized by source. Each source folder should contain a source yaml, model yaml, and staging models.
+
+#### Naming Convention
+The source yaml should follow the naming convention:
+```
+_stg_[source]__sources.yml
+```
+
+The model yaml should follow the naming convention:
+```
+_stg_[source]__models.yml
+```
+
+The staging model should follow the naming convention:
+```
+ stg_[source]__[source_table_name].sql
+```
+
+#### Best Practices
+- The staging layer can contain the following transformations:
+  - renaming
+  - type casting
+  - basic computations (e.g. cents to dollars)
+  - categorizing (e.g. using condition logic to group values via a case when statement)
+The staging layer should **not** contain transformation like joins or aggregations. 
+- The staging layer should almost always exclude deleted records. 
+- If a base model exists, the staging model should `ref()` the base model.
+- The staging model is generated differently depending if it is a SCD1 or SCD2 table.
+- The staging models should be materialized as views.
+
+#### Model Structure
+If the table is a SCD1 table, then the model structure:
+```sql
+with
+    source as (
+        select * from {{ source('[source]', '[source_table_name]') }}
+        -- If DML (insert, update, delete) indicator type field(s) exist, then conditional(s) on the field(s) to exclude deleted records
+        where
+            _fivetran_deleted != true
+    ),
+
+    renamed as (
+        select
+            field1,
+            field2,
+            .
+            .
+            .
+        from source
+    )
+
+select * from renamed
+```
+The SCD1 tables should be generated using the dbt package codegen.
+
+If the table is a SCD2 table, then the model structure:
+```sql
+/*  The partition columns are:
+    ['column1', 'column2', ..., 'columnn']
+*/
+
+with
+    source as (
+            select * from {{ source('[source]', '[source_table_name]') }}
+            -- If DML (insert, update, delete) indicator type field(s) exist, then conditional(s) on the field(s) to exclude deleted records
+            where
+                _fivetran_deleted != true
+    ),
+
+    valid_to as (
+        ...
+    ),
+
+    final as (
+        ...
+    )
+
+select * from final
+```
+
+The SCD2 tables should be generated using a SCD2 table generator macro. SCD2 tables should be listed in a separate source yaml file. The SCD2 yaml file should follow the naming convention:
+```
+_stg_[source]__sources_effdt.yml
+```
+
+## dbt_project_name/seeds/
+- Description of the `seeds` folder
+
+## dbt_project_name/snapshots/
+- Description of the `snapshots` folder
+
+## dbt_project_name/tests/
+- Description of the `tests` folder
+
+## 

--- a/cdp-docs/docs/program_overview/practitioner/guides/modeling_guide.md
+++ b/cdp-docs/docs/program_overview/practitioner/guides/modeling_guide.md
@@ -203,4 +203,7 @@ _stg_[source]__sources_effdt.yml
 ## dbt_project_name/tests/
 - Description of the `tests` folder
 
-## 
+## Common Modeling Topics
+### Optimizing query times with CTEs
+### Parsing semi-structured data
+### Joining SCD2 tables


### PR DESCRIPTION
A majority of the guides are empty. The current code provides a skeleton/placeholders for expected guides. 

The dbt Project Modeling Guide is the only guide that has documentation included in this PR. Some genera, staging, and reverse etl documentation is included.

We are expecting to onboard a couple of different contractors soon. Jessica has given the O.K. to publish in-progress guides. 

Recommended to view in webpage form. 

Please feel free to add any additional comments, ideas, etc to this PR thread.